### PR TITLE
accept any type that implements ToString

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rchan"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 description = "4chan api wrapper and client."
 authors = [ "Taylan Gökkaya <insomnimus.dev@gmail.com>" ]

--- a/src/client.rs
+++ b/src/client.rs
@@ -37,7 +37,7 @@ impl Client {
     where
         T: serde::de::DeserializeOwned,
     {
-        let resp = self.client.get(path).send().await?;
+        let resp = self.client.get(path.to_string()).send().await?;
 
         if !resp.status().is_success() {
             return Err(Error::status_code(resp.status()));
@@ -60,9 +60,13 @@ impl Client {
     ///
     /// # Arguments
     /// -  `board_abv`: The abbreviation of a board for example `mu`. Corresponds to the `abv` field of a [`Board`].
-    pub async fn get_board_catalog(&self, board_abv: &str) -> Result<Catalog> {
-        self.json::<Catalog>(&format!("{}{}/catalog.json", crate::BASE, board_abv))
-            .await
+    pub async fn get_board_catalog(&self, board_abv: impl ToString) -> Result<Catalog> {
+        self.json::<Catalog>(&format!(
+            "{}{}/catalog.json",
+            crate::BASE,
+            board_abv.to_string()
+        ))
+        .await
     }
 
     /// Gets a full [`Thread`].
@@ -70,11 +74,15 @@ impl Client {
     /// # Arguments
     /// -  `board_abv`: The abbreviation of a board; the `abv` field of a [`Board`].
     /// -  `thread_no`: The no of a thread. Can be obtained by calling [`crate::thread::ThreadInfo::thread_no`]. Corresponds to the `no` field of the OP.
-    pub async fn get_full_thread(&self, board_abv: &str, thread_no: u32) -> Result<Thread> {
+    pub async fn get_full_thread(
+        &self,
+        board_abv: impl ToString,
+        thread_no: u32,
+    ) -> Result<Thread> {
         self.json::<Thread>(&format!(
             "{}{}/thread/{}.json",
             crate::BASE,
-            board_abv,
+            board_abv.to_string(),
             thread_no
         ))
         .await

--- a/src/post.rs
+++ b/src/post.rs
@@ -102,15 +102,15 @@ impl Post {
     /// therefore this is currently an argument.
     ///
     /// Calling this method with an invalid board name results in an invalid URL, not `None`.
-    pub fn attachment_url(&self, board: &str) -> Option<String> {
-        self.attachment.as_ref().map(|a| a.url(board))
+    pub fn attachment_url(&self, board: impl ToString) -> Option<String> {
+        self.attachment.as_ref().map(|a| a.url(board.to_string()))
     }
 
     /// Returns the thumbnail URL for this post, if there is any.
     ///
     /// # Arguments
     /// -  `board`: The abbreviation of the board this post was posted in.
-    pub fn thumbnail_url(&self, board: &str) -> Option<String> {
+    pub fn thumbnail_url(&self, board: impl ToString) -> Option<String> {
         self.attachment.as_ref().map(|a| a.thumbnail_url(board))
     }
 }
@@ -120,10 +120,10 @@ impl Attachment {
     ///
     /// # Arguments
     /// -  `board`: The abbreviation of the board this attachment is in. (The api does not include it in the attachment).
-    pub fn url(&self, board: &str) -> String {
+    pub fn url(&self, board: impl ToString) -> String {
         format!(
             "https://i.4cdn.org/{board}/{post_no}{ext}",
-            board = board,
+            board = board.to_string(),
             ext = &self.ext,
             post_no = &self.id,
         )
@@ -133,10 +133,10 @@ impl Attachment {
     ///
     /// # Arguments
     /// -  `board`: The abbreviation of the board this post was posted in.
-    pub fn thumbnail_url(&self, board: &str) -> String {
+    pub fn thumbnail_url(&self, board: impl ToString) -> String {
         format!(
             "https://i.4cdn.org/{board}/{post_no}s{ext}",
-            board = board,
+            board = board.to_string(),
             ext = &self.ext,
             post_no = &self.id,
         )


### PR DESCRIPTION
makes some functions accept any type that implements ToString instead of just `&str`.
still accepts `&str` so there shouldn't be any breaking changed.